### PR TITLE
Adding duplex feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,7 @@ Options passed through to the underlying `vinyl-fs`.  Can include options like `
 
 Creates a stream that html files can be piped into -- html files in, script or style files out.
 
-#### config.selector
-#### config.attribute
-#### config.cwd
+#### config.selector, config.attribute, config.cwd
 
 See above
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,16 @@ Default: `{}`
 
 Options passed through to the underlying `vinyl-fs`.  Can include options like `read` and `buffer`.
 
+### domSrc.duplex(config)
+
+Creates a stream that html files can be piped into -- html files in, script or style files out.
+
+#### config.selector
+#### config.attribute
+#### config.cwd
+
+See above
+
 End-to-End Concatenation and Minification
 -------------
 

--- a/index.js
+++ b/index.js
@@ -1,14 +1,25 @@
 var vinylFs = require('vinyl-fs');
 var cheerio = require('cheerio');
+var through = require('through2');
+var vinylFile = require('vinyl-file');
+var async = require('async');
+var extend = require('extend');
 var fs = require('fs');
 var path = require('path');
 
-module.exports = function(config){
+module.exports = domSrc;
 
+function domSrc(config){
     var html = fs.readFileSync(path.join(process.cwd(),config.file),'utf8');
+    var files = findFilenames(html, config);
+
+    return vinylFs.src(files,config.options || {});
+}
+
+function findFilenames(html, config) {
     var $ = cheerio.load(html);
 
-    var files = $(config.selector).map(function(i,elem){
+    return $(config.selector).map(function(i,elem){
         return $(elem).attr(config.attribute);
     }).toArray().filter(function(item){
         return (item !== undefined && item.substring(0,4) !== 'http' && item.substring(0,2) !== '//');
@@ -16,6 +27,34 @@ module.exports = function(config){
         var cwd = config.cwd ? config.cwd : path.dirname(config.file);
         return path.join(cwd,item);
     });
+}
 
-    return vinylFs.src(files,config.options || {});
+domSrc.duplex = function(config) {
+    return through.obj(findAndReadFiles);
+
+    function findAndReadFiles(htmlFile, encoding, throughCallback) {
+        // copy config and set config.file to current html file
+        // so cwd is resolved correctly when scanning html for filenames
+        var configCopy = extend({}, config);
+        configCopy.file = htmlFile.path;
+
+        var html = htmlFile.contents.toString();
+        var filenames = findFilenames(html, configCopy);
+
+        if (filenames.length == 0) {
+            return throughCallback();
+        }
+
+        var throughStream = this;
+        async.eachSeries(filenames, function(filename, eachCallback) {
+            vinylFile.read(filename, function(err, file) {
+                if (err) return eachCallback(err);
+
+                throughStream.push(file);
+                eachCallback();
+            });
+        }, function(err) {
+            throughCallback(err);
+        });
+    }
 };

--- a/package.json
+++ b/package.json
@@ -18,13 +18,17 @@
   "author": "Chris Gross",
   "license": "MIT",
   "dependencies": {
-    "vinyl-fs": "~0.1.0",
-    "cheerio": "~0.13.1"
+    "async": "~0.9.0",
+    "cheerio": "~0.13.1",
+    "extend": "~2.0.0",
+    "node-extend": "~0.2.0",
+    "through2": "~0.4.1",
+    "vinyl-file": "~1.1.1",
+    "vinyl-fs": "~0.1.0"
   },
   "devDependencies": {
     "mocha": "~1.17.1",
     "should": "~3.1.3",
-    "through2": "~0.4.1",
     "buffer-equal": "0.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "async": "~0.9.0",
     "cheerio": "~0.13.1",
     "extend": "~2.0.0",
-    "node-extend": "~0.2.0",
     "through2": "~0.4.1",
     "vinyl-file": "~1.1.1",
     "vinyl-fs": "~0.1.0"

--- a/test/fixture/bad-script-tag.html
+++ b/test/fixture/bad-script-tag.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <!-- references js file that does not exist -->
+  <script src="not-found.js"></script>
+</body>
+</html>

--- a/test/fixture/template1.html
+++ b/test/fixture/template1.html
@@ -1,0 +1,6 @@
+<html>
+<body>
+  <script src="one.js"></script>
+  <script src="two.js"></script>
+</body>
+</html>

--- a/test/fixture/template2.html
+++ b/test/fixture/template2.html
@@ -1,0 +1,5 @@
+<html>
+<body>
+  <script src="three.js"></script>
+</body>
+</html>

--- a/test/test.js
+++ b/test/test.js
@@ -1,5 +1,4 @@
 var path = require('path');
-var fs = require('fs');
 var should = require('should');
 var domSrc = require('../index');
 var vfs = require('vinyl-fs');
@@ -12,39 +11,103 @@ var dataWrap = function(fn) {
     };
 };
 
-it('should read the script tags src into the stream', function (done) {
+describe('src (default) mode', function () {
+    it('should read the script tags src into the stream', function (done) {
 
-    var onEnd = function(){
-        buffered.length.should.equal(3);
-        should.exist(buffered[0].stat);
-        buffered[0].path.should.equal(path.resolve('test/fixture/one.js'));
-        buffered[1].path.should.equal(path.resolve('test/fixture/two.js'));
-        buffered[2].path.should.equal(path.resolve('test/fixture/three.js'));
-        done();
-    };
+        var onEnd = function(){
+            buffered.length.should.equal(3);
+            should.exist(buffered[0].stat);
+            buffered[0].path.should.equal(path.resolve('test/fixture/one.js'));
+            buffered[1].path.should.equal(path.resolve('test/fixture/two.js'));
+            buffered[2].path.should.equal(path.resolve('test/fixture/three.js'));
+            done();
+        };
 
-    var stream = domSrc({file:'test/fixture/fixture.html',selector:'script',attribute:'src'});
+        var stream = domSrc({file:'test/fixture/fixture.html',selector:'script',attribute:'src'});
 
-    var buffered = [];
-    var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
-    stream.pipe(bufferStream);
+        var buffered = [];
+        var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+        stream.pipe(bufferStream);
 
+    });
+
+    it('should use the cwd property correctly.', function (done) {
+
+        var onEnd = function(){
+            buffered.length.should.equal(1);
+            should.exist(buffered[0].stat);
+            buffered[0].path.should.equal(path.resolve('test/fixture/one.js'));
+            done();
+        };
+
+        var stream = domSrc({file:'test/fixture/subdir/subdir.html',selector:'script',attribute:'src',cwd:'test/fixture'});
+
+        var buffered = [];
+        var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+        stream.pipe(bufferStream);
+
+    });
 });
 
-it('should use the cwd property correctly.', function (done) {
+describe('duplex mode', function () {
+    it('should process html piped into it', function(done) {
 
-    var onEnd = function(){
-        buffered.length.should.equal(1);
-        should.exist(buffered[0].stat);
-        buffered[0].path.should.equal(path.resolve('test/fixture/one.js'));
-        done();
-    };
+        var onEnd = function(){
+            buffered.length.should.equal(3);
+            should.exist(buffered[0].stat);
+            buffered[0].path.should.equal(path.resolve('test/fixture/one.js'));
+            buffered[1].path.should.equal(path.resolve('test/fixture/two.js'));
+            buffered[2].path.should.equal(path.resolve('test/fixture/three.js'));
+            done();
+        };
 
-    var stream = domSrc({file:'test/fixture/subdir/subdir.html',selector:'script',attribute:'src',cwd:'test/fixture'});
+        var stream = vfs.src('test/fixture/fixture.html')
+            .pipe(domSrc.duplex({
+                selector:'script',
+                attribute:'src'
+            }));
 
-    var buffered = [];
-    var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
-    stream.pipe(bufferStream);
+        var buffered = [];
+        var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+        stream.pipe(bufferStream);
+    });
 
+    it('should use the cwd property correctly.', function (done) {
+
+        var onEnd = function(){
+            buffered.length.should.equal(1);
+            should.exist(buffered[0].stat);
+            buffered[0].path.should.equal(path.resolve('test/fixture/one.js'));
+            done();
+        };
+
+        var stream = vfs.src('test/fixture/subdir/subdir.html')
+            .pipe(domSrc.duplex({
+                selector:'script',
+                attribute:'src',
+                cwd: 'test/fixture'
+            }));
+
+        var buffered = [];
+        var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+        stream.pipe(bufferStream);
+    });
+
+    it('should still work when finding nothing in html', function(done) {
+
+        var onEnd = function(){
+            buffered.length.should.equal(0);
+            done();
+        };
+
+        var stream = vfs.src('test/fixture/fixture.html')
+            .pipe(domSrc.duplex({
+                selector:'script',
+                attribute:'wont-find-this-attribute'
+            }));
+
+        var buffered = [];
+        var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+        stream.pipe(bufferStream);
+    });
 });
-

--- a/test/test.js
+++ b/test/test.js
@@ -132,4 +132,24 @@ describe('duplex mode', function () {
         var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
         stream.pipe(bufferStream);
     });
+
+    it('should emit an error when a referenced file is not found', function(done) {
+
+        var onEnd = function(){
+            done(new Error('onEnd should not have been called'));
+        };
+
+        var stream = vfs.src('test/fixture/bad-script-tag.html')
+            .pipe(domSrc.duplex({
+                selector:'script',
+                attribute:'src'
+            }));
+
+        var buffered = [];
+        var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+
+        stream.on('error', function(err) {
+            done();
+        }).pipe(bufferStream);
+    });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -110,4 +110,26 @@ describe('duplex mode', function () {
         var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
         stream.pipe(bufferStream);
     });
+
+    it('should handle multiple incoming html files', function(done) {
+
+        var onEnd = function(){
+            buffered.length.should.equal(3);
+            should.exist(buffered[0].stat);
+            buffered[0].path.should.equal(path.resolve('test/fixture/one.js'));
+            buffered[1].path.should.equal(path.resolve('test/fixture/two.js'));
+            buffered[2].path.should.equal(path.resolve('test/fixture/three.js'));
+            done();
+        };
+
+        var stream = vfs.src('test/fixture/template{1,2}.html')
+            .pipe(domSrc.duplex({
+                selector:'script',
+                attribute:'src'
+            }));
+
+        var buffered = [];
+        var bufferStream = through.obj(dataWrap(buffered.push.bind(buffered)), onEnd);
+        stream.pipe(bufferStream);
+    });
 });


### PR DESCRIPTION
Here's my attempt at making gulp-dom-src writeable for #2.

I added a "duplex" function to domSrc which is where the write/read stream comes from. The existing cheerio code was reusable.

After scanning the html for script/style references, it reads them one by one using [vinyl-file](https://www.npmjs.com/package/vinyl-file) with [async](https://www.npmjs.com/package/async) and sends them down the stream.

A really basic usage example:

```js
var gulp = require('gulp');
var domSrc = require('gulp-dom-src');
var concat = require('gulp-concat');

gulp.task('go', function() {
  return gulp.src('index.html')
    .pipe(domSrc.duplex({
      selector: 'script',
      attribute: 'src'
    }))
    .pipe(concat('bundle.js'))
    .pipe(gulp.dest('build/'));
});
```