### PR TITLE
Vinyl fs update

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "extend": "~2.0.0",
     "through2": "~0.4.1",
     "vinyl-file": "~1.1.1",
-    "vinyl-fs": "~0.1.0"
+    "vinyl-fs": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "~1.17.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-dom-src",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Create a gulp stream from script/link tags in an HTML file.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Updates vinyl-fs dependency to use latest version. Fixes #6 .
With gulp^4.0.0 and vinyl-fs ^3.0.0 upgrades, vinyl files being piped to gulp.dest() failed a check which looks for a _isVinyl property. The old version of vinyl-fs used by this repo did not add this property when the file is created by Vinyl, so the error would be thrown by dest().